### PR TITLE
variable defaults fix and output tweak

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -4,10 +4,7 @@
 #
 # Purpose: The following script defines the output for the mysql database system
 
-
-
 output "mysql_db_system" {
   description = "MySQL Database DBSystem"
   value       = oci_mysql_mysql_db_system.DBSystem
-  sensitive   = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,14 +15,17 @@ variable "tenancy_ocid" {
 
 variable "user_ocid" {
   description = "User OCID in tenancy"
+  default = ""
 }
 
 variable "fingerprint" {
   description = "API Key Fingerprint for user_ocid derived from public API Key imported in OCI User config"
+  default = ""
 }
 
 variable "private_key_path" {
   description = "Private Key Absolute path location where terraform is executed"
+  default = ""
 }
 
 /********** Provider Variables NOT OVERLOADABLE **********/


### PR DESCRIPTION
Variable defaults fix - necessary for ORM usage, other repos are failing in ORM due to this
Output tweak - sensitive=true should be a choice of the implementer of an architecture which uses this module. the current definition forces such implementer to use sensitive=true, even when he doesn't wish to.